### PR TITLE
Fix `time_t` incorrect type

### DIFF
--- a/src/unix/newlib/mod.rs
+++ b/src/unix/newlib/mod.rs
@@ -28,8 +28,15 @@ pub type socklen_t = u32;
 pub type speed_t = u32;
 pub type suseconds_t = i32;
 pub type tcflag_t = ::c_uint;
-pub type time_t = i32;
 pub type useconds_t = u32;
+
+cfg_if! {
+    if #[cfg(target_os = "horizon")] {
+        pub type time_t = ::c_longlong;
+    } else {
+        pub type time_t = i32;
+    }
+}
 
 s! {
     // The order of the `ai_addr` field in this struct is crucial


### PR DESCRIPTION
This results in garbage data coming back from e.g. `gmtime()`.

I am also working on a local change to add tests for `armv6k-nintendo-3ds` which would hopefully catch something like this in the future. If I get it to a reasonable shape I can make a PR, although it might be a bit heavy to include while we are still waiting on the upstream merge to `libc`.