### PR TITLE
Add getrandom call on horizon OS

### DIFF
--- a/src/unix/newlib/horizon/mod.rs
+++ b/src/unix/newlib/horizon/mod.rs
@@ -190,5 +190,7 @@ extern "C" {
         value: *mut ::c_void,
     ) -> ::c_int;
 
+    pub fn getrandom(buf: *mut ::c_void, buflen: ::size_t, flags: ::c_uint) -> ::ssize_t;
+
     pub fn gethostid() -> ::c_long;
 }


### PR DESCRIPTION
Ref https://github.com/Meziu/rust-horizon/issues/6, https://github.com/Meziu/rust-linker-fix-3ds/pull/8

Side note: it might be useful to rebase this repo onto upstream again so the version number matches, but perhaps not strictly necessary.

As @Meziu mentioned, this probably won't be the only libc change needed during the course of `std` testing (I think `__errno()` might be another one we'd want, as mentioned in https://github.com/rust-lang/libc/issues/1995). It's nice that upstream merged the fork, but maybe we're not ready to switch completely to it just yet.