### PR TITLE
Add `getrandom` constants

### DIFF
--- a/src/unix/newlib/horizon/mod.rs
+++ b/src/unix/newlib/horizon/mod.rs
@@ -147,6 +147,10 @@ pub const FIONBIO: ::c_ulong = 1;
 
 pub const RTLD_DEFAULT: *mut ::c_void = 0 as *mut ::c_void;
 
+// For getrandom()
+pub const GRND_NONBLOCK: ::c_uint = 0x1;
+pub const GRND_RANDOM: ::c_uint = 0x2;
+
 // Horizon OS works doesn't or can't hold any of this information
 safe_f! {
     pub {const} fn WIFSTOPPED(_status: ::c_int) -> bool {

--- a/src/unix/newlib/horizon/mod.rs
+++ b/src/unix/newlib/horizon/mod.rs
@@ -190,5 +190,7 @@ extern "C" {
         value: *mut ::c_void,
     ) -> ::c_int;
 
+    pub fn getrandom(buf: *mut ::c_void, buflen: ::size_t, flags: ::c_uint) -> ::ssize_t;
+
     pub fn gethostid() -> ::c_long;
 }


### PR DESCRIPTION
I'm not sure what happened but it seems like Github doesn't love the diff with rebase, so it's showing a diff here...

I forgot to add these constants which are used by https://github.com/Meziu/rust-linker-fix-3ds/pull/8