### PR TITLE
Add some extensions to pthread for armv6k-nintendo-3ds

### DIFF
--- a/src/unix/newlib/horizon/mod.rs
+++ b/src/unix/newlib/horizon/mod.rs
@@ -194,6 +194,12 @@ extern "C" {
         value: *mut ::c_void,
     ) -> ::c_int;
 
+    pub fn pthread_attr_setpriority(attr: *mut ::pthread_attr_t, priority: ::c_int) -> ::c_int;
+
+    pub fn pthread_attr_setaffinity(attr: *mut ::pthread_attr_t, affinity: ::c_int) -> ::c_int;
+
+    pub fn pthread_getpriority() -> ::c_int;
+
     pub fn getrandom(buf: *mut ::c_void, buflen: ::size_t, flags: ::c_uint) -> ::ssize_t;
 
     pub fn gethostid() -> ::c_long;


### PR DESCRIPTION
The pthread_attr_t type can have priority and affinity values set.
pthread_getpriority returns the priority of the current thread.

These are needed to enable std thread support. std can't link directly with libctru so we go through pthread as an intermediate interface.