### PR TITLE
Fix uid_t and gid_t sizes on horizon

### DIFF
--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -23,12 +23,20 @@ pub type uintptr_t = usize;
 pub type ssize_t = isize;
 
 pub type pid_t = i32;
-pub type uid_t = u32;
-pub type gid_t = u32;
 pub type in_addr_t = u32;
 pub type in_port_t = u16;
 pub type sighandler_t = ::size_t;
 pub type cc_t = ::c_uchar;
+
+cfg_if! {
+    if #[cfg(target_os = "horizon")] {
+        pub type uid_t = ::c_ushort;
+        pub type gid_t = ::c_ushort;
+    } else {
+        pub type uid_t = u32;
+        pub type gid_t = u32;
+    }
+}
 
 #[cfg_attr(feature = "extra_traits", derive(Debug))]
 pub enum DIR {}


### PR DESCRIPTION
Part of the fix for https://github.com/Meziu/rust-horizon/issues/11

This makes `struct stat` behave as expected, particularly for `size_t`.