### PR TITLE
Use `libc-test` for horizon OS

### DIFF
--- a/libc-test/Cargo.toml
+++ b/libc-test/Cargo.toml
@@ -20,6 +20,10 @@ cc = "1.0.61"
 # FIXME: Use fork ctest until the maintainer gets back.
 ctest2 = "0.4.3"
 
+[target.armv6k-nintendo-3ds.dev-dependencies]
+linker-fix-3ds = { git = "https://github.com/Meziu/rust-linker-fix-3ds.git" }
+pthread-3ds = { git = "https://github.com/Meziu/pthread-3ds.git" }
+
 [features]
 default = [ "std" ]
 std = [ "libc/std" ]

--- a/libc-test/Cargo.toml
+++ b/libc-test/Cargo.toml
@@ -21,14 +21,16 @@ cc = "1.0.61"
 ctest2 = "0.4.3"
 
 [target.armv6k-nintendo-3ds.dev-dependencies]
+ctru = { package = "ctru-rs", git = "https://github.com/Meziu/ctru-rs.git" }
 linker-fix-3ds = { git = "https://github.com/Meziu/rust-linker-fix-3ds.git" }
 pthread-3ds = { git = "https://github.com/Meziu/pthread-3ds.git" }
+scopeguard = "1.1.0"
 
 [features]
-default = [ "std" ]
-std = [ "libc/std" ]
-align = [ "libc/align" ]
-extra_traits = [ "libc/extra_traits" ]
+default = ["std"]
+std = ["libc/std"]
+align = ["libc/align"]
+extra_traits = ["libc/extra_traits"]
 
 [[test]]
 name = "main"

--- a/libc-test/test/cmsg.rs
+++ b/libc-test/test/cmsg.rs
@@ -3,7 +3,7 @@
 
 extern crate libc;
 
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os = "horizon")))]
 mod t {
 
     use libc::{self, c_uchar, c_uint, c_void, cmsghdr, msghdr};

--- a/libc-test/test/main.rs
+++ b/libc-test/test/main.rs
@@ -1,6 +1,9 @@
 #![allow(bad_style, improper_ctypes, deprecated)]
 extern crate libc;
 
+extern crate ctru;
+extern crate scopeguard;
+
 use libc::*;
 
 include!(concat!(env!("OUT_DIR"), "/main.rs"));

--- a/libc-test/test/semver.rs
+++ b/libc-test/test/semver.rs
@@ -7,6 +7,11 @@ extern crate libc;
 include!(concat!(env!("OUT_DIR"), "/semver.rs"));
 
 fn main() {
+    #[cfg(target_os = "horizon")]
+    linker_fix_3ds::init();
+    #[cfg(target_os = "horizon")]
+    pthread_3ds::init();
+
     // The test is about the imports created in `semver.rs`.
     println!("PASSED 1 tests");
 }

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -23,12 +23,20 @@ pub type uintptr_t = usize;
 pub type ssize_t = isize;
 
 pub type pid_t = i32;
-pub type uid_t = u32;
-pub type gid_t = u32;
 pub type in_addr_t = u32;
 pub type in_port_t = u16;
 pub type sighandler_t = ::size_t;
 pub type cc_t = ::c_uchar;
+
+cfg_if! {
+    if #[cfg(target_os = "horizon")] {
+        pub type uid_t = ::c_ushort;
+        pub type gid_t = ::c_ushort;
+    } else {
+        pub type uid_t = u32;
+        pub type gid_t = u32;
+    }
+}
 
 #[cfg_attr(feature = "extra_traits", derive(Debug))]
 pub enum DIR {}

--- a/src/unix/newlib/horizon/mod.rs
+++ b/src/unix/newlib/horizon/mod.rs
@@ -147,6 +147,10 @@ pub const FIONBIO: ::c_ulong = 1;
 
 pub const RTLD_DEFAULT: *mut ::c_void = 0 as *mut ::c_void;
 
+// For getrandom()
+pub const GRND_NONBLOCK: ::c_uint = 0x1;
+pub const GRND_RANDOM: ::c_uint = 0x2;
+
 // Horizon OS works doesn't or can't hold any of this information
 safe_f! {
     pub {const} fn WIFSTOPPED(_status: ::c_int) -> bool {

--- a/src/unix/newlib/horizon/mod.rs
+++ b/src/unix/newlib/horizon/mod.rs
@@ -190,5 +190,7 @@ extern "C" {
         value: *mut ::c_void,
     ) -> ::c_int;
 
+    pub fn getrandom(buf: *mut ::c_void, buflen: ::size_t, flags: ::c_uint) -> ::ssize_t;
+
     pub fn gethostid() -> ::c_long;
 }

--- a/src/unix/newlib/horizon/mod.rs
+++ b/src/unix/newlib/horizon/mod.rs
@@ -6,7 +6,6 @@ pub type c_ulong = u32;
 
 pub type wchar_t = ::c_uint;
 
-pub type in_port_t = ::c_ushort;
 pub type u_register_t = ::c_uint;
 pub type u_char = ::c_uchar;
 pub type u_short = ::c_ushort;
@@ -34,7 +33,7 @@ s! {
 
     pub struct sockaddr_in {
         pub sin_family: ::sa_family_t,
-        pub sin_port: in_port_t,
+        pub sin_port: ::in_port_t,
         pub sin_addr: ::in_addr,
     }
 

--- a/src/unix/newlib/horizon/mod.rs
+++ b/src/unix/newlib/horizon/mod.rs
@@ -194,6 +194,12 @@ extern "C" {
         value: *mut ::c_void,
     ) -> ::c_int;
 
+    pub fn pthread_attr_setpriority(attr: *mut ::pthread_attr_t, priority: ::c_int) -> ::c_int;
+
+    pub fn pthread_attr_setaffinity(attr: *mut ::pthread_attr_t, affinity: ::c_int) -> ::c_int;
+
+    pub fn pthread_getpriority() -> ::c_int;
+
     pub fn getrandom(buf: *mut ::c_void, buflen: ::size_t, flags: ::c_uint) -> ::ssize_t;
 
     pub fn gethostid() -> ::c_long;

--- a/src/unix/newlib/horizon/mod.rs
+++ b/src/unix/newlib/horizon/mod.rs
@@ -35,6 +35,7 @@ s! {
         pub sin_family: ::sa_family_t,
         pub sin_port: ::in_port_t,
         pub sin_addr: ::in_addr,
+        pub sin_zero: [::c_uchar; 8],
     }
 
     pub struct sockaddr_in6 {

--- a/src/unix/newlib/mod.rs
+++ b/src/unix/newlib/mod.rs
@@ -163,10 +163,6 @@ s! {
         pub f_namemax: ::c_ulong,
     }
 
-    pub struct sigset_t {
-        __val: [::c_ulong; 16],
-    }
-
     pub struct sigaction {
         pub sa_handler: extern fn(arg1: ::c_int),
         pub sa_mask: sigset_t,
@@ -239,6 +235,18 @@ s! {
     pub struct pthread_rwlockattr_t { // Unverified
         __lockkind: ::c_int,
         __pshared: ::c_int,
+    }
+}
+
+cfg_if! {
+    if #[cfg(target_os = "horizon")] {
+        pub type sigset_t = ::c_ulong;
+    } else {
+        s! {
+            pub struct sigset_t {
+                __val: [::c_ulong; 16],
+            }
+        }
     }
 }
 

--- a/src/unix/newlib/mod.rs
+++ b/src/unix/newlib/mod.rs
@@ -129,25 +129,6 @@ s! {
         pub tm_isdst: ::c_int,
     }
 
-    pub struct stat {
-        pub st_dev: ::dev_t,
-        pub st_ino: ::ino_t,
-        pub st_mode: ::mode_t,
-        pub st_nlink: ::nlink_t,
-        pub st_uid: ::uid_t,
-        pub st_gid: ::gid_t,
-        pub st_rdev: dev_t,
-        pub st_size: off_t,
-        pub st_atime: time_t,
-        pub st_spare1: ::c_long,
-        pub st_mtime: time_t,
-        pub st_spare2: ::c_long,
-        pub st_ctime: time_t,
-        pub st_spare3: ::c_long,
-        pub st_blksize: blksize_t,
-        pub st_blocks: blkcnt_t,
-        pub st_spare4: [::c_long; 2usize],
-    }
 
     pub struct statvfs {
         pub f_bsize: ::c_ulong,
@@ -241,10 +222,49 @@ s! {
 cfg_if! {
     if #[cfg(target_os = "horizon")] {
         pub type sigset_t = ::c_ulong;
+
+        s! {
+            pub struct stat {
+                pub st_dev: ::dev_t,
+                pub st_ino: ::ino_t,
+                pub st_mode: ::mode_t,
+                pub st_nlink: ::nlink_t,
+                pub st_uid: ::uid_t,
+                pub st_gid: ::gid_t,
+                pub st_rdev: dev_t,
+                pub st_size: off_t,
+                pub st_atim: ::timespec,
+                pub st_mtim: ::timespec,
+                pub st_ctim: ::timespec,
+                pub st_blksize: blksize_t,
+                pub st_blocks: blkcnt_t,
+                pub st_spare4: [::c_long; 2usize],
+            }
+        }
     } else {
         s! {
             pub struct sigset_t {
                 __val: [::c_ulong; 16],
+            }
+
+            pub struct stat {
+                pub st_dev: ::dev_t,
+                pub st_ino: ::ino_t,
+                pub st_mode: ::mode_t,
+                pub st_nlink: ::nlink_t,
+                pub st_uid: ::uid_t,
+                pub st_gid: ::gid_t,
+                pub st_rdev: dev_t,
+                pub st_size: off_t,
+                pub st_atime: time_t,
+                pub st_spare1: ::c_long,
+                pub st_mtime: time_t,
+                pub st_spare2: ::c_long,
+                pub st_ctime: time_t,
+                pub st_spare3: ::c_long,
+                pub st_blksize: blksize_t,
+                pub st_blocks: blkcnt_t,
+                pub st_spare4: [::c_long; 2usize],
             }
         }
     }
@@ -291,7 +311,14 @@ pub const __PTHREAD_RWLOCK_INT_FLAGS_SHARED: usize = 1;
 pub const PTHREAD_MUTEX_NORMAL: ::c_int = 0;
 pub const PTHREAD_MUTEX_RECURSIVE: ::c_int = 1;
 pub const PTHREAD_MUTEX_ERRORCHECK: ::c_int = 2;
-pub const FD_SETSIZE: usize = 1024;
+
+cfg_if! {
+    if #[cfg(target_os = "horizon")] {
+        pub const FD_SETSIZE: usize = 64;
+    } else {
+        pub const FD_SETSIZE: usize = 1024;
+    }
+}
 // intentionally not public, only used for fd_set
 const ULONG_SIZE: usize = 32;
 


### PR DESCRIPTION
In the interest of https://github.com/Meziu/rust-horizon/issues/6 – this takes a first pass at using the libc test runner to compare ABIs and type sizes, but could be improved to include function signatures, constants, etc.

My plan is not to merge this as-is, but break out the functional changes in `libc` and deliver them separately. Maybe we want a "testing" branch for this to run the tests?

Edit: a few instructions on how to actually run this, I forgot:

- Use a horizon-std toolchain
- Apply this patch for `ctest2` to support the target:
```diff
diff --git a/src/lib.rs b/src/lib.rs
index c5c65ca..5126b8d 100644
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1122,6 +1122,8 @@ fn default_cfg(target: &str) -> Vec<(String, Option<String>)> {
         ("vxworks", "unix", "")
     } else if target.contains("haiku") {
         ("haiku", "unix", "")
+    } else if target.contains("nintendo-3ds") {
+        ("horizon", "unix", "newlib")
     } else {
         panic!("unknown os/family: {}", target)
     };
```
- Set up patches in `libc-test/.cargo/config.toml`:
```toml
[patch.crates-io]
ctest2 = { path = "your/ctest2/fork" }

[patch."https://github.com/Meziu/libc.git"]
libc = { path = ".." }

[env]
CC_armv6k_nintendo_3ds = "/opt/devkitpro/devkitARM/bin/arm-none-eabi-gcc"
AR_armv6k_nintendo_3ds = "/opt/devkitpro/devkitARM/bin/arm-none-eabi-ar"
```
- `cargo 3ds test --test main`. Other tests have link errors currently
----

Let me know if anything looks off here or you have questions, but I think this is a decent  point for us to test some ABI mismatches and stuff.

@Meziu @AzureMarker