### PR TITLE
Rename "idealprocessor" attr functions to "processorid"

### DIFF
--- a/src/unix/newlib/horizon/mod.rs
+++ b/src/unix/newlib/horizon/mod.rs
@@ -212,14 +212,14 @@ extern "C" {
         param: *const sched_param,
     ) -> ::c_int;
 
-    pub fn pthread_attr_getidealprocessor_np(
+    pub fn pthread_attr_getprocessorid_np(
         attr: *const ::pthread_attr_t,
-        ideal_processor: *mut ::c_int,
+        processor_id: *mut ::c_int,
     ) -> ::c_int;
 
-    pub fn pthread_attr_setidealprocessor_np(
+    pub fn pthread_attr_setprocessorid_np(
         attr: *mut ::pthread_attr_t,
-        ideal_processor: ::c_int,
+        processor_id: ::c_int,
     ) -> ::c_int;
 
     pub fn pthread_getschedparam(
@@ -233,7 +233,7 @@ extern "C" {
         policy: ::c_int,
         param: *const ::sched_param,
     ) -> ::c_int;
-    
+
     pub fn pthread_getprocessorid_np() -> ::c_int;
 
     pub fn getrandom(buf: *mut ::c_void, buflen: ::size_t, flags: ::c_uint) -> ::ssize_t;


### PR DESCRIPTION
Just a small naming tweak.